### PR TITLE
Refactor message types and driver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "OS8104A",
-  "version": "1.0.6",
+  "name": "socketmost",
+  "version": "2.0.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "OS8104A",
-      "version": "1.0.6",
+      "name": "socketmost",
+      "version": "2.0.11",
       "dependencies": {
         "onoff": "^6.0.3",
         "socket.io": "^4.7.1",

--- a/src/client/SocketMost-Client.ts
+++ b/src/client/SocketMost-Client.ts
@@ -1,143 +1,151 @@
-import {DataGram} from './DataGram'
+import { DataGram } from './DataGram'
 import EventEmitter from 'events'
 import {
-    AllocResult,
-    MasterFoundEvent,
-    MessageOnly,
-    NodePosition,
-    Os8104Events,
-    RawMostRxMessage, RetrieveAudio, SocketMostSendMessage,
-    SocketTypes, Stream
-} from "../modules/Messages";
+  AllocResult,
+  MasterFoundEvent,
+  MessageOnly,
+  NodePosition,
+  Os8104Events,
+  MostRxMessage,
+  RetrieveAudio,
+  SocketMostSendMessage,
+  SocketTypes,
+  Stream,
+} from '../modules/Messages'
 
-export class SocketMostClient extends EventEmitter{
-    client: DataGram
-    maxPosition: number
-    nodePosition: number
+export class SocketMostClient extends EventEmitter {
+  client: DataGram
+  maxPosition: number
+  nodePosition: number
 
-    constructor() {
-        super()
-        this.client = new DataGram("/tmp/SocketMost-client.sock", "/tmp/SocketMost.sock");
+  constructor() {
+    super()
+    this.client = new DataGram(
+      '/tmp/SocketMost-client.sock',
+      '/tmp/SocketMost.sock',
+    )
 
-        this.client.on("connect", () => {
-            console.log("connected")
-            this.getPositions().then(() => {
-                console.log("resolved")
-            })
-        });
+    this.client.on('connect', () => {
+      console.log('connected')
+      this.getPositions().then(() => {
+        console.log('resolved')
+      })
+    })
 
-        this.maxPosition = 0
-        this.nodePosition = 0
+    this.maxPosition = 0
+    this.nodePosition = 0
 
-        this.client.on("data", (data) => {
-            const event: Os8104Events = JSON.parse(data.toString()).eventType
-            switch (event) {
-                case Os8104Events.SocketMostMessageRxEvent:{
-                    const message: RawMostRxMessage = JSON.parse(data.toString())
-                    this.emit(Os8104Events.SocketMostMessageRxEvent, message)
-                    break
-                }
-                case Os8104Events.PositionUpdate: {
-                    const message: NodePosition = JSON.parse(data.toString())
-                    this.maxPosition = message.maxPosition
-                    this.nodePosition = message.nodePosition
-                    this.emit(Os8104Events.PositionUpdate, message)
-                    break
-                }
-                case Os8104Events.Locked:
-                    this.emit(Os8104Events.Locked)
-                    break
-                case Os8104Events.MessageSent:
-                    this.emit(Os8104Events.MessageSent)
-                    break
-                case Os8104Events.MasterFoundEvent:{
-                    const message: MasterFoundEvent = JSON.parse(data.toString())
-                    this.emit(Os8104Events.MasterFoundEvent, message)
-                    break
-                }
-                case Os8104Events.AllocResult: {
-                    const message: AllocResult = JSON.parse(data.toString())
-                    this.emit(Os8104Events.AllocResult, message)
-                    break
-                }
-                default:
-                    console.log("no match", event)
-            }
-        });
-    }
+    this.client.on('data', data => {
+      const event: Os8104Events = JSON.parse(data.toString()).eventType
+      switch (event) {
+        case Os8104Events.SocketMostMessageRxEvent: {
+          const message: MostRxMessage = JSON.parse(data.toString())
+          this.emit(Os8104Events.SocketMostMessageRxEvent, message)
+          break
+        }
+        case Os8104Events.PositionUpdate: {
+          const message: NodePosition = JSON.parse(data.toString())
+          this.maxPosition = message.maxPosition
+          this.nodePosition = message.nodePosition
+          this.emit(Os8104Events.PositionUpdate, message)
+          break
+        }
+        case Os8104Events.Locked:
+          this.emit(Os8104Events.Locked)
+          break
+        case Os8104Events.MessageSent:
+          this.emit(Os8104Events.MessageSent)
+          break
+        case Os8104Events.MasterFoundEvent: {
+          const message: MasterFoundEvent = JSON.parse(data.toString())
+          this.emit(Os8104Events.MasterFoundEvent, message)
+          break
+        }
+        case Os8104Events.AllocResult: {
+          const message: AllocResult = JSON.parse(data.toString())
+          this.emit(Os8104Events.AllocResult, message)
+          break
+        }
+        default:
+          console.log('no match', event)
+      }
+    })
+  }
 
-    getPositions(): Promise<void> {
-        return new Promise((resolve, reject) => {
-            const data: MessageOnly = {
-                eventType: SocketTypes.GetNodePosition
-            }
-            this.sendAppMessage(data)
-            const positionTimeout = setTimeout(() => {
-                reject('Get Node Position Message Time Out')
-                console.log('position request timed out')
-            }, 20)
-            this.once('positionUpdate', () => {
-                console.log('resolving')
-                clearTimeout(positionTimeout)
-                resolve()
-            })
-        })
-    }
+  getPositions(): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const data: MessageOnly = {
+        eventType: SocketTypes.GetNodePosition,
+      }
+      this.sendAppMessage(data)
+      const positionTimeout = setTimeout(() => {
+        reject('Get Node Position Message Time Out')
+        console.log('position request timed out')
+      }, 20)
+      this.once('positionUpdate', () => {
+        console.log('resolving')
+        clearTimeout(positionTimeout)
+        resolve()
+      })
+    })
+  }
 
-    // parseMostMessage (message) {
-    //     let data = {
-    //         fBlockID: message.data.readUint8(0),
-    //         instanceID: message.data.readUint8(1),
-    //         fktID: (message.data.slice(2,4).readUint16BE() >> 4),
-    //         opType: ((message.data.readUint16BE(2) & 0xF)),
-    //         telId: (message.data.readUint8(4) & 0xF0) >>4,
-    //         telLen: (message.data.readUint8(4) & 0xF),
-    //         data: message.type > 0x01 ? message.data.slice(5, message.data.length - 1) : message.data.slice(5),
-    //         sourceAddrHigh: message.sourceAddrHigh,
-    //         sourceAddrLow: message.sourceAddrLow
-    //     }
-    //
-    //     let messageOut = {...data}
-    //     messageOut.data = [...message.data]
-    //     if(!this.networkMaster) {
-    //         if(message.fBlockID === 2) {
-    //             console.log("network master found")
-    //         }
-    //     }
-    //     return data
-    // }
+  // parseMostMessage (message) {
+  //     let data = {
+  //         fBlockID: message.data.readUint8(0),
+  //         instanceID: message.data.readUint8(1),
+  //         fktId: (message.data.slice(2,4).readUint16BE() >> 4),
+  //         opType: ((message.data.readUint16BE(2) & 0xF)),
+  //         telId: (message.data.readUint8(4) & 0xF0) >>4,
+  //         telLen: (message.data.readUint8(4) & 0xF),
+  //         data: message.type > 0x01 ? message.data.slice(5, message.data.length - 1) : message.data.slice(5),
+  //         sourceAddrHigh: message.sourceAddrHigh,
+  //         sourceAddrLow: message.sourceAddrLow
+  //     }
+  //
+  //     let messageOut = {...data}
+  //     messageOut.data = [...message.data]
+  //     if(!this.networkMaster) {
+  //         if(message.fBlockID === 2) {
+  //             console.log("network master found")
+  //         }
+  //     }
+  //     return data
+  // }
 
-    sendAppMessage(data: SocketMostSendMessage | MessageOnly) {
-        this.client.write(JSON.stringify(data))
-    }
+  sendAppMessage(data: SocketMostSendMessage | MessageOnly) {
+    this.client.write(JSON.stringify(data))
+  }
 
-    getMaster() {
-        this.client.write(JSON.stringify({eventType: 'getMaster'}) + '\r\n')
-    }
+  getMaster() {
+    this.client.write(JSON.stringify({ eventType: 'getMaster' }) + '\r\n')
+  }
 
-    sendControlMessage(data: SocketMostSendMessage): Promise<void> {
-        return new Promise((resolve, reject) => {
-            this.client.write(JSON.stringify({eventType: 'sendControlMessage', ...data}))
-            const controlMessageTimeout = setTimeout(() => {
-                reject('sendMessage request timed out')
-            }, 50)
-            this.once('messageSent', () => {
-                console.log('resolving sent Message')
-                clearTimeout(controlMessageTimeout)
-                resolve()
-            })
-        })
-    }
+  sendControlMessage(data: SocketMostSendMessage): Promise<void> {
+    return new Promise((resolve, reject) => {
+      this.client.write(
+        JSON.stringify({ eventType: 'sendControlMessage', ...data }),
+      )
+      const controlMessageTimeout = setTimeout(() => {
+        reject('sendMessage request timed out')
+      }, 50)
+      this.once('messageSent', () => {
+        console.log('resolving sent Message')
+        clearTimeout(controlMessageTimeout)
+        resolve()
+      })
+    })
+  }
 
-    allocate() {
-        this.client.write(JSON.stringify({eventType: 'allocate'}))
-    }
+  allocate() {
+    this.client.write(JSON.stringify({ eventType: 'allocate' }))
+  }
 
-    stream(data: Stream) {
-        this.client.write(JSON.stringify({eventType: 'stream', ...data}) + '\r\n')
-    }
+  stream(data: Stream) {
+    this.client.write(JSON.stringify({ eventType: 'stream', ...data }) + '\r\n')
+  }
 
-    retrieveAudio(data: RetrieveAudio) {
-        this.client.write(JSON.stringify({eventType: 'retrieveAudio', ...data}))
-    }
+  retrieveAudio(data: RetrieveAudio) {
+    this.client.write(JSON.stringify({ eventType: 'retrieveAudio', ...data }))
+  }
 }

--- a/src/driver/GpioConfig.ts
+++ b/src/driver/GpioConfig.ts
@@ -1,0 +1,25 @@
+import { spawnSync } from 'child_process'
+
+type GpioConfig = {
+  interrupt: number
+  fault: number
+  status: number
+  mostStatus: number
+  reset: number
+}
+
+export const getPiGpioConfig = (): GpioConfig => {
+  const piCheckResult = spawnSync('cat', [
+    '/sys/firmware/devicetree/base/model',
+  ])
+  const isPi5 = piCheckResult.stdout.toString().includes('Pi 5')
+  return isPi5
+    ? {
+        interrupt: 404,
+        fault: 405,
+        status: 415,
+        mostStatus: 425,
+        reset: 416,
+      }
+    : { interrupt: 5, fault: 6, status: 16, mostStatus: 25, reset: 17 }
+}

--- a/src/driver/OS8104A.ts
+++ b/src/driver/OS8104A.ts
@@ -1,655 +1,679 @@
-import {Gpio} from "onoff"
-import spi, {type SpiDevice, type SpiOptions} from "spi-device"
-import EventEmitter from "events"
-import {getRegisterConfig} from "./RegisterConfig"
-import {Registers} from "./Registers"
-import {spawnSync} from 'child_process'
+import { Gpio } from 'onoff'
+import spi, { type SpiDevice, type SpiOptions } from 'spi-device'
+import EventEmitter from 'events'
+import { getRegisterConfig } from './RegisterConfig'
+import { Registers } from './Registers'
 import {
-    AllocResult,
-    Mode,
-    MostMessage,
-    Os8104Events,
-    RawMostRxMessage,
-    SocketMostSendMessage,
-    SourceResult,
-    Stream
-} from "../modules/Messages";
+  AllocResult,
+  Mode,
+  Os8104Events,
+  MostRxMessage,
+  SocketMostSendMessage,
+  SourceResult,
+  Stream,
+  TargetMostMessage,
+} from '../modules/Messages'
+import { getPiGpioConfig } from './GpioConfig'
 
 const TRANSFER_SPEED = 180000
 
 const options: SpiOptions = {
-    chipSelectHigh: false,
-    bitsPerWord: 8,
-    lsbFirst: false
-}
-
-const enum Pi5Gpio {
-    interrupt = 404,
-    fault= 405,
-    status= 415,
-    mostStatus= 425,
-    reset= 416
-}
-
-const enum PiGpio {
-    interrupt = 5,
-    fault= 6,
-    status= 16,
-    mostStatus= 25,
-    reset= 17
+  chipSelectHigh: false,
+  bitsPerWord: 8,
+  lsbFirst: false,
 }
 
 export class OS8104A extends EventEmitter {
-    readonly freq: number
-    readonly spi: SpiDevice
-    readonly interrupt: Gpio
-    readonly fault: Gpio
-    readonly status: Gpio
-    pi5: boolean
-    getRegisterConfig: typeof getRegisterConfig
-    mostStatus: Gpio
-    reset: Gpio
-    nodeAddressBuf: Buffer
-    groupAddressBuf: Buffer
-    awaitAlloc: boolean
-    allocResult?: AllocResult
-    awaitGetSource: boolean
-    getSourceResult: SourceResult | null
-    allocTimeout?: NodeJS.Timeout
-    streamAllocTimeout?: NodeJS.Timeout
-    delayTimer?: NodeJS.Timeout
-    getSourceTimeout?: NodeJS.Timeout
-    allocCheck?: NodeJS.Timer
-    lockInterval?: NodeJS.Timer
-    multiPartMessage?: MostMessage
-    multiPartSequence: number
-    transceiverLocked: boolean
-    result : any
+  readonly freq: number
+  readonly spi: SpiDevice
+  readonly interrupt: Gpio
+  readonly fault: Gpio
+  readonly status: Gpio
+  getRegisterConfig: typeof getRegisterConfig
+  mostStatus: Gpio
+  reset: Gpio
+  nodeAddressBuf: Buffer
+  groupAddressBuf: Buffer
+  awaitAlloc: boolean
+  allocResult?: AllocResult
+  awaitGetSource: boolean
+  getSourceResult: SourceResult | null
+  allocTimeout?: NodeJS.Timeout
+  streamAllocTimeout?: NodeJS.Timeout
+  delayTimer?: NodeJS.Timeout
+  getSourceTimeout?: NodeJS.Timeout
+  allocCheck?: NodeJS.Timer
+  lockInterval?: NodeJS.Timer
+  multiPartMessage?: TargetMostMessage<number[]>
+  multiPartSequence: number
+  transceiverLocked: boolean
 
-    constructor(nodeAddress: number, groupAddress: number, freq: number) {
-        super()
-        this.spi = spi.openSync(0, 0, options)
+  constructor(nodeAddress: number, groupAddress: number, freq: number) {
+    super()
+    this.spi = spi.openSync(0, 0, options)
 
-        this.result = spawnSync('cat', ['/sys/firmware/devicetree/base/model'])
-        this.pi5 = this.result.stdout.toString().includes('Pi 5')
-        this.interrupt = new Gpio(this.pi5 ? 404 : 5, "in", "falling")
-        // TODO this had an unnoticed type error for debounce, now TS has saved the day, it may mess things up
-        // now that it's actually working
-        this.fault = new Gpio(this.pi5 ? 405 : 6, "in", "both", { debounceTimeout: 50 })
-        this.status = new Gpio(this.pi5 ? 415 : 16, "in", "both", { debounceTimeout: 50 })
-        this.mostStatus = new Gpio(this.pi5 ? 425 : 26, "in", "both", { debounceTimeout: 10 })
-        this.reset = new Gpio(this.pi5 ? 416 : 17, "out")
-        this.freq = freq
-        // TODO not sure why these were buffers, need to review
-        this.nodeAddressBuf = Buffer.alloc(2)
-        this.nodeAddressBuf.writeUint16BE(nodeAddress)
-        this.groupAddressBuf = Buffer.alloc(1)
-        this.groupAddressBuf.writeUInt8(groupAddress)
-        this.awaitAlloc = false
-        this.awaitGetSource = false
-        this.getSourceResult = null
-        this.multiPartSequence = 0
-        this.transceiverLocked = true
+    const gpiConfig = getPiGpioConfig()
+    this.interrupt = new Gpio(gpiConfig.interrupt, 'in', 'falling')
+    // TODO this had an unnoticed type error for debounce, now TS has saved the day, it may mess things up
+    // now that it's actually working
+    this.fault = new Gpio(gpiConfig.fault, 'in', 'both', {
+      debounceTimeout: 50,
+    })
+    this.status = new Gpio(gpiConfig.status, 'in', 'both', {
+      debounceTimeout: 50,
+    })
+    this.mostStatus = new Gpio(gpiConfig.mostStatus, 'in', 'both', {
+      debounceTimeout: 10,
+    })
+    this.reset = new Gpio(gpiConfig.reset, 'out')
+    this.freq = freq
+    // TODO not sure why these were buffers, need to review
+    this.nodeAddressBuf = Buffer.alloc(2)
+    this.nodeAddressBuf.writeUint16BE(nodeAddress)
+    this.groupAddressBuf = Buffer.alloc(1)
+    this.groupAddressBuf.writeUInt8(groupAddress)
+    this.awaitAlloc = false
+    this.awaitGetSource = false
+    this.getSourceResult = null
+    this.multiPartSequence = 0
+    this.transceiverLocked = true
+    this.startUp()
+    this.getRegisterConfig = getRegisterConfig
+
+    this.fault.watch((err, val) => {
+      if (err) {
+        throw err
+      }
+      console.log('fault', val)
+    })
+
+    this.status.watch((err, val) => {
+      if (err) {
+        throw err
+      }
+      console.log('status', val)
+    })
+
+    this.mostStatus.watch((err, val) => {
+      if (err) {
+        throw err
+      }
+      if (val === 1) {
+        console.log('status lost')
+        this.writeReg(Registers.REG_bXCR, [
+          this.readSingleReg(Registers.REG_bXCR) &
+            ~Registers.bXCR_OUTPUT_ENABLE,
+        ])
         this.startUp()
-        this.getRegisterConfig = getRegisterConfig
+      } else {
+        console.log('network status up')
+        this.writeReg(Registers.REG_bXCR, [
+          this.readSingleReg(Registers.REG_bXCR) | Registers.bXCR_OUTPUT_ENABLE,
+        ])
+      }
+    })
+  }
 
-        this.fault.watch((err, val) => {
-            if (err) {
-                throw err
-            }
-            console.log("fault", val)
-        })
-
-        this.status.watch((err, val) => {
-            if (err) {
-                throw err
-            }
-            console.log("status", val)
-        })
-
-        this.mostStatus.watch((err, val) => {
-            if (err) {
-                throw err
-            }
-            if (val === 1) {
-                console.log("status lost")
-                this.writeReg(Registers.REG_bXCR, [
-                    this.readSingleReg(Registers.REG_bXCR) & ~Registers.bXCR_OUTPUT_ENABLE
-                ])
-                this.startUp()
-            } else {
-                console.log("network status up")
-                this.writeReg(Registers.REG_bXCR, [
-                    this.readSingleReg(Registers.REG_bXCR) | Registers.bXCR_OUTPUT_ENABLE
-                ])
-            }
-        })
-    }
-
-    startUp(): void {
-        console.log("resetting")
-        this.interrupt.unwatchAll()
-        this.reset.writeSync(0)
-        this.wait(200)
-            .then(() => {
-                this.reset.writeSync(1)
-                this.interrupt.watch(() => {
-                    this.resetOs8104()
-                })
-            })
-            .catch((reason) => {
-                throw reason
-            })
-    }
-
-    resetOs8104(): void {
-        this.interrupt.unwatchAll()
-        this.runConfig()
-    }
-
-    runConfig(): void {
-        console.log("running config")
-        for (const entry of this.getRegisterConfig(
-            {
-                nodeAddressLow: this.nodeAddressBuf[1],
-                nodeAddressHigh: this.nodeAddressBuf[0],
-                groupAddress: this.groupAddressBuf[0]
-            },
-            Mode.leg
-        )) {
-            console.log("0", entry[0])
-            console.log("1", entry[1])
-            this.writeReg(entry[0], [entry[1]])
-        }
+  startUp(): void {
+    console.log('resetting')
+    this.interrupt.unwatchAll()
+    this.reset.writeSync(0)
+    this.wait(200)
+      .then(() => {
+        this.reset.writeSync(1)
         this.interrupt.watch(() => {
-            this.interruptHandler()
+          this.resetOs8104()
         })
+      })
+      .catch(reason => {
+        throw reason
+      })
+  }
+
+  resetOs8104(): void {
+    this.interrupt.unwatchAll()
+    this.runConfig()
+  }
+
+  runConfig(): void {
+    console.log('running config')
+    for (const entry of this.getRegisterConfig(
+      {
+        nodeAddressLow: this.nodeAddressBuf[1],
+        nodeAddressHigh: this.nodeAddressBuf[0],
+        groupAddress: this.groupAddressBuf[0],
+      },
+      Mode.leg,
+    )) {
+      console.log('0', entry[0])
+      console.log('1', entry[1])
+      this.writeReg(entry[0], [entry[1]])
     }
+    this.interrupt.watch(() => {
+      this.interruptHandler()
+    })
+  }
 
-    async wait(ms: number): Promise<void> {
-        await new Promise((resolve) => setTimeout(resolve, ms));
+  async wait(ms: number): Promise<void> {
+    await new Promise(resolve => setTimeout(resolve, ms))
+  }
+
+  writeReg(address: number, value: number[] = []): number | null {
+    const message = [
+      {
+        byteLength: 2 + value.length,
+        sendBuffer: Buffer.from([0x00, address, ...value]),
+        receiveBuffer: Buffer.alloc(2 + value.length),
+        speedHz: TRANSFER_SPEED,
+      },
+    ]
+
+    this.spi.transferSync(message)
+    // debugPrint(`Register write: 0x${addr.toString(16)} => 0x${value.toString(16)}`);
+    return message[0].receiveBuffer[1]
+  }
+
+  readReg(address: number, bytes = 1): Buffer {
+    this.writeReg(address)
+    const message = [
+      {
+        byteLength: 1,
+        sendBuffer: Buffer.from([0x01]),
+        speedHz: TRANSFER_SPEED,
+      },
+      {
+        byteLength: bytes,
+        receiveBuffer: Buffer.alloc(bytes),
+        speedHz: TRANSFER_SPEED,
+      },
+    ]
+    this.spi.transferSync(message)
+    if (message[1].receiveBuffer !== undefined) {
+      return message[1].receiveBuffer
+    } else {
+      return Buffer.alloc(1)
     }
+  }
 
-    writeReg(address: number, value: number[] = []): number | null {
-        const message = [
-            {
-                byteLength: 2 + value.length,
-                sendBuffer: Buffer.from([0x00, address, ...value]),
-                receiveBuffer: Buffer.alloc(2 + value.length),
-                speedHz: TRANSFER_SPEED
-            }
-        ]
-
-        this.spi.transferSync(message)
-        // debugPrint(`Register write: 0x${addr.toString(16)} => 0x${value.toString(16)}`);
-        return message[0].receiveBuffer[1]
+  readSingleReg(address: number): number {
+    this.writeReg(address)
+    const message = [
+      {
+        byteLength: 1,
+        sendBuffer: Buffer.from([0x01]),
+        speedHz: TRANSFER_SPEED,
+      },
+      {
+        byteLength: 1,
+        receiveBuffer: Buffer.alloc(1),
+        speedHz: TRANSFER_SPEED,
+      },
+    ]
+    this.spi.transferSync(message)
+    if (message[1].receiveBuffer !== undefined) {
+      return message[1].receiveBuffer[0]
+    } else {
+      return -1
     }
+  }
 
-    readReg(address: number, bytes = 1): Buffer {
-        this.writeReg(address)
-        const message = [
-            {
-                byteLength: 1,
-                sendBuffer: Buffer.from([0x01]),
-                speedHz: TRANSFER_SPEED
-            },
-            {
-                byteLength: bytes,
-                receiveBuffer: Buffer.alloc(bytes),
-                speedHz: TRANSFER_SPEED
-            }
-        ]
-        this.spi.transferSync(message)
-        if (message[1].receiveBuffer !== undefined) {
-            return message[1].receiveBuffer
-        } else {
-            return Buffer.alloc(1)
-        }
-    }
-
-    readSingleReg(address: number): number {
-        this.writeReg(address)
-        const message = [
-            {
-                byteLength: 1,
-                sendBuffer: Buffer.from([0x01]),
-                speedHz: TRANSFER_SPEED
-            },
-            {
-                byteLength: 1,
-                receiveBuffer: Buffer.alloc(1),
-                speedHz: TRANSFER_SPEED
-            }
-        ]
-        this.spi.transferSync(message)
-        if (message[1].receiveBuffer !== undefined) {
-            return message[1].receiveBuffer[0]
-        } else {
-            return -1
-        }
-    }
-
-    interruptHandler(): void {
-        // Read interrupts
-        const interrupts = this.readSingleReg(Registers.REG_bMSGS)
-        if ((interrupts & Registers.bMSGS_MESS_RECEIVED) > 0) {
-            this.parseMostMessage(this.readReg(0xa0, 20))
-            this.writeReg(Registers.REG_bMSGC, [
-                this.readSingleReg(Registers.REG_bMSGC) |
-                    Registers.bMSGC_RESET_MESSAGE_RX_INT |
-                    Registers.bMSGC_RECEIVE_BUFF_EN
-            ])
-        } else if ((interrupts & Registers.bMSGS_ERR) > 0) {
-            console.log("error active")
-            if (this.transceiverLocked) {
-                this.parseFault(this.readSingleReg(Registers.REG_bXSR))
-            }
-        } else if ((interrupts & Registers.bMSGS_MESS_TRANSMITTED) > 0) {
-            this.writeReg(Registers.REG_bMSGC, [
-                this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_RESET_MESSAGE_TX_INT
-            ])
-            if (this.awaitAlloc) {
-                const res = this.readReg(Registers.REG_mXCMB, 20)
-                this.allocResult = this.parseAllocateResponse(res)
-                this.emit(Os8104Events.AllocResult, this.allocResult)
-                this.writeReg(Registers.REG_bMSGC, [
-                    this.readSingleReg(Registers.REG_bMSGC) & ~Registers.bMSGC_START_TX
-                ])
-                this.awaitAlloc = false
-                clearTimeout(this.allocTimeout)
-            } else if (this.awaitGetSource) {
-                const res = this.readReg(Registers.REG_mXCMB, 20)
-                this.getSourceResult = this.parseRemoteGetSource(res)
-                console.log("remote source result", this.getSourceResult, res)
-                this.emit(Os8104Events.GetSourceResult, this.getSourceResult)
-                this.writeReg(Registers.REG_bMSGC, [
-                    this.readSingleReg(Registers.REG_bMSGC) & ~Registers.bMSGC_START_TX
-                ])
-                this.awaitGetSource = false
-                clearTimeout(this.getSourceTimeout)
-
-            }
-            this.emit(Os8104Events.MessageSent)
-        } else if ((interrupts & Registers.bMSGS_NET_CHANGED) > 0) {
-            console.log("net changed")
-            this.writeReg(Registers.REG_bMSGC, [
-                this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_RESET_NET_CONF_CHANGE
-            ])
-        } else {
-            console.log("unknown")
-        }
-    }
-
-    parseMostMessage(message: Buffer) {
-        const data: RawMostRxMessage = {
-            type: message.readUint8(0),
-            sourceAddrHigh: message.readUint8(1),
-            sourceAddrLow: message.readUint8(2),
-            fBlockID: message.readUint8(3),
-            instanceID: message.readUint8(4),
-            fktID: (message.slice(5,7).readUint16BE() >> 4),
-            opType: ((message.readUint16BE(5) & 0xF)),
-            telID: (message.readUint8(7) & 0xF0) >>4,
-            telLen: (message.readUint8(7) & 0xF),
-            data: message.readUint8(0) > 0x01 ? message.slice(8, message.length - 1) : message.slice(8)
-            }
-        this.emit(Os8104Events.MostMessageRx, data)
-    }
-
-    parseFault(data: number): void {
-        console.log("Error", this.fault.readSync(), data)
-        const masks = this.readSingleReg(Registers.REG_bXSR)
-        if ((data & Registers.bXSR_TRANS_LOCK_ACT) > 0) {
-            if ((masks & Registers.bXSR_LOCK_ERR_MASK) === 0 && this.transceiverLocked) {
-                this.transceiverLocked = false
-                this.emit(Os8104Events.Unlocked)
-                this.lockInterval = setInterval(() => {
-                    this.checkForLock()
-                }, 100)
-            }
-        } else {
-            console.log("resetting in parse")
-            this.writeReg(Registers.REG_bMSGC, [
-                this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_RESET_ERR_INT
-            ])
-        }
-    }
-
-    sendControlMessage(
-        {
-            targetAddressHigh,
-            targetAddressLow,
-            fBlockID,
-            instanceID,
-            fktId,
-            opType,
-            data
-        }: SocketMostSendMessage,
-        telId = 0
-    ): void {
-        if (data.length > 12) {
-            this.multiPartMessage = {
-                targetAddressHigh,
-                targetAddressLow,
-                fBlockID,
-                instanceID,
-                fktId,
-                opType,
-                data: [...data]
-            }
-            this.multiPartSequence = 0
-            this.sendMultiPartMessage()
-        } else {
-            if (this.transceiverLocked) {
-                const header = Buffer.alloc(9)
-                header.writeUInt8(0x01, 0)
-                header.writeUInt8(0x00, 1)
-                header.writeUInt8(targetAddressHigh, 2)
-                header.writeUInt8(targetAddressLow, 3)
-                header.writeUInt8(fBlockID, 4)
-                header.writeUInt8(instanceID, 5)
-                header.writeUInt16BE((fktId << 4) | opType, 6)
-                header.writeUInt8(telId | data.length, 8)
-                const buf = Buffer.alloc(21)
-                const tempData = Buffer.concat([header, Buffer.from(data)])
-                tempData.copy(buf, 0, 0, tempData.length)
-                this.writeReg(0xc0, [...buf])
-                this.writeReg(Registers.REG_bMSGC, [
-                    this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_START_TX
-                ])
-            } else {
-                console.log("CAN'T SEND NO LOCK")
-            }
-        }
-    }
-
-    sendMultiPartMessage(): void {
-        const tempMessage = { ...this.multiPartMessage! }
-        this.multiPartMessage!.data.length > 11
-            ? (tempMessage.data = this.multiPartMessage!.data.splice(0, 11))
-            : (tempMessage.data = this.multiPartMessage!.data)
-        tempMessage.data = [this.multiPartSequence, ...tempMessage.data]
-        let telId
-        // In a multipart message telId represents the beginning, middle and end of the message, telId = 1 means first message, telId = 2 means message continuing
-        // telId = 3 means final message
-        if (this.multiPartSequence === 0) {
-            telId = 1
-        } else if (this.multiPartMessage!.data.length < 11) {
-            telId = 3
-        } else {
-            telId = 2
-        }
-        this.sendControlMessage(tempMessage, telId)
-        if (telId !== 3) {
-            this.once("messageSent", () => {
-                this.multiPartSequence += 1
-                this.sendMultiPartMessage()
-            })
-        }
-    }
-
-    getNodePosition(): number {
-        return this.readSingleReg(Registers.REG_bNPR)
-    }
-
-    getMaxPosition(): number {
-        return this.readSingleReg(Registers.REG_bMPR)
-    }
-
-    allocate(): void {
-        const header = Buffer.alloc(7)
-        header.writeUInt8(0x01, 0)
-        header.writeUInt8(0x03, 1)
-        header.writeUInt8(0x04, 2)
-        header.writeUInt8(0x00, 3)
-        header.writeUInt8(0x00, 4)
-        header.writeUInt8(0x04, 5)
-        header.writeUInt8(0x00, 6)
-        this.writeReg(0xc0, [...header])
+  interruptHandler(): void {
+    // Read interrupts
+    const interrupts = this.readSingleReg(Registers.REG_bMSGS)
+    if ((interrupts & Registers.bMSGS_MESS_RECEIVED) > 0) {
+      this.parseMostMessage(this.readReg(0xa0, 20))
+      this.writeReg(Registers.REG_bMSGC, [
+        this.readSingleReg(Registers.REG_bMSGC) |
+          Registers.bMSGC_RESET_MESSAGE_RX_INT |
+          Registers.bMSGC_RECEIVE_BUFF_EN,
+      ])
+    } else if ((interrupts & Registers.bMSGS_ERR) > 0) {
+      console.log('error active')
+      if (this.transceiverLocked) {
+        this.parseFault(this.readSingleReg(Registers.REG_bXSR))
+      }
+    } else if ((interrupts & Registers.bMSGS_MESS_TRANSMITTED) > 0) {
+      this.writeReg(Registers.REG_bMSGC, [
+        this.readSingleReg(Registers.REG_bMSGC) |
+          Registers.bMSGC_RESET_MESSAGE_TX_INT,
+      ])
+      if (this.awaitAlloc) {
+        const res = this.readReg(Registers.REG_mXCMB, 20)
+        this.allocResult = this.parseAllocateResponse(res)
+        this.emit(Os8104Events.AllocResult, this.allocResult)
         this.writeReg(Registers.REG_bMSGC, [
-            this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_START_TX
+          this.readSingleReg(Registers.REG_bMSGC) & ~Registers.bMSGC_START_TX,
         ])
-        this.awaitAlloc = true
-        this.allocTimeout = setTimeout(() => {
-            this.awaitAlloc = false
-            console.log("ALLOCATE TIMEOUT")
-        }, 500)
-    }
-
-    getRemoteSource(connectionLabel: number): void {
-        const header = Buffer.alloc(7)
-        header.writeUInt8(0x01, 0)
-        header.writeUInt8(0x05, 1)
-        header.writeUInt8(0x03, 2)
-        header.writeUInt8(0xc8, 3)
-        header.writeUInt8(0x00, 4)
-        header.writeUInt8(connectionLabel, 5)
-        header.writeUInt8(0x00, 6)
-        this.writeReg(0xc0, [...header])
+        this.awaitAlloc = false
+        clearTimeout(this.allocTimeout)
+      } else if (this.awaitGetSource) {
+        const res = this.readReg(Registers.REG_mXCMB, 20)
+        this.getSourceResult = this.parseRemoteGetSource(res)
+        console.log('remote source result', this.getSourceResult, res)
+        this.emit(Os8104Events.GetSourceResult, this.getSourceResult)
         this.writeReg(Registers.REG_bMSGC, [
-            this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_START_TX
+          this.readSingleReg(Registers.REG_bMSGC) & ~Registers.bMSGC_START_TX,
         ])
-        this.awaitGetSource = true
-        this.getSourceTimeout = setTimeout(() => {
-            this.awaitGetSource = false
-            console.log("Remote TIMEOUT")
-        }, 500)
+        this.awaitGetSource = false
+        clearTimeout(this.getSourceTimeout)
+      }
+      this.emit(Os8104Events.MessageSent)
+    } else if ((interrupts & Registers.bMSGS_NET_CHANGED) > 0) {
+      console.log('net changed')
+      this.writeReg(Registers.REG_bMSGC, [
+        this.readSingleReg(Registers.REG_bMSGC) |
+          Registers.bMSGC_RESET_NET_CONF_CHANGE,
+      ])
+    } else {
+      console.log('unknown')
     }
+  }
 
-    checkForLock(): void {
-        const lockStatus = this.readSingleReg(Registers.REG_bCM2)
-        const pllLocked = lockStatus & Registers.bCM2_UNLOCKED
-        const lockSource = this.readSingleReg(Registers.REG_bXSR) & Registers.bXSR_FREQ_REG_ACT
-        if (pllLocked === 0 && lockSource === 0) {
-            this.emit(Os8104Events.Locked)
-            this.writeReg(Registers.REG_bMSGC, [
-                this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_RESET_ERR_INT
-            ])
-            this.transceiverLocked = true
-            clearInterval(this.lockInterval)
-        }
+  parseMostMessage(message: Buffer) {
+    const data: MostRxMessage = {
+      type: message.readUint8(0),
+      sourceAddrHigh: message.readUint8(1),
+      sourceAddrLow: message.readUint8(2),
+      fBlockID: message.readUint8(3),
+      instanceID: message.readUint8(4),
+      fktId: message.slice(5, 7).readUint16BE() >> 4,
+      opType: message.readUint16BE(5) & 0xf,
+      telID: (message.readUint8(7) & 0xf0) >> 4,
+      telLen: message.readUint8(7) & 0xf,
+      data:
+        message.readUint8(0) > 0x01
+          ? message.slice(8, message.length - 1)
+          : message.slice(8),
     }
+    this.emit(Os8104Events.MostMessageRx, data)
+  }
 
-    parseAllocateResponse(data: Buffer): AllocResult {
-        const answer1 = data.readUint8(7)
-        const answer2 = data.readUint8(8)
-        const cl = data.readUint8(9)
-        const loc1 = data.readUint8(9)
-        const loc2 = data.readUint8(10)
-        const loc3 = data.readUint8(11)
-        const loc4 = data.readUint8(12)
-        const result: AllocResult = {
-            loc1,
-            loc2,
-            loc3,
-            loc4,
-            cl
-        }
-        switch (answer1) {
-            case 1:
-                result.answer1 = "ALLOC_GRANT"
-                result.freeChannels = answer2
-                break
-            case 2:
-                result.answer1 = "ALLOC_BUSY"
-                result.freeChannels = answer2
-                break
-            case 3:
-                result.answer1 = "ALLOC_DENY"
-                result.freeChannels = answer2
-                break
-            case 4:
-                result.answer1 = "WRONG_TARGET"
-                result.freeChannels = answer2
-                break
-            default:
-                result.answer1 = "ERROR"
-                result.freeChannels = 0
-        }
-        return result
+  parseFault(data: number): void {
+    console.log('Error', this.fault.readSync(), data)
+    const masks = this.readSingleReg(Registers.REG_bXSR)
+    if ((data & Registers.bXSR_TRANS_LOCK_ACT) > 0) {
+      if (
+        (masks & Registers.bXSR_LOCK_ERR_MASK) === 0 &&
+        this.transceiverLocked
+      ) {
+        this.transceiverLocked = false
+        this.emit(Os8104Events.Unlocked)
+        this.lockInterval = setInterval(() => {
+          this.checkForLock()
+        }, 100)
+      }
+    } else {
+      console.log('resetting in parse')
+      this.writeReg(Registers.REG_bMSGC, [
+        this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_RESET_ERR_INT,
+      ])
     }
+  }
 
-    stream({ sourceAddrHigh, sourceAddrLow, fBlockID, instanceID, sinkNr }: Stream): void {
-        this.allocResult = {
-            loc1: -1,
-            loc2: -1,
-            loc3: -1,
-            loc4: -1,
-            cl: -1
-        }
-        this.allocate()
-        this.waitForAlloc(sourceAddrHigh, sourceAddrLow, fBlockID, instanceID, sinkNr)
-    }
-
-    retrieveAudio(bytes: { "0": number; "1": number; "2"?: number; "3"?: number }): void {
-        console.log("retrieve audio in os8104", bytes)
-        const bytesT: number[] = []
-        bytesT.push(bytes["0"])
-        bytesT.push(bytes["1"])
-        if (bytes["2"] !== undefined) {
-            bytesT.push(bytes["2"])
-        }
-        if (bytes["3"] !== undefined) {
-            bytesT.push(bytes["3"])
-        }
-        this.setMrtSink1(bytesT)
-    }
-
-    waitForAlloc(
-        sourceAddrHigh: number,
-        sourceAddrLow: number,
-        fBlockID: number,
-        instanceID: number,
-        sinkNr: number
-    ): void {
-        this.allocCheck = setInterval(() => {
-            if (this.allocResult !== null) {
-                console.log("alloc done, setting MRT")
-                clearTimeout(this.streamAllocTimeout)
-                clearInterval(this.allocCheck)
-                this.setMrtSource1({sourceAddrHigh, sourceAddrLow, fBlockID, instanceID, sinkNr})
-            }
-        }, 20)
-        this.streamAllocTimeout = setTimeout(() => {
-            clearInterval(this.allocCheck)
-            console.log("stream audio timed out on alloc check")
-        }, 1000)
-    }
-
-    parseRemoteGetSource(data: Buffer): SourceResult {
-        const nodePos = data.readUint8(10)
-        const group = data.readUint8(12)
-        const logicalHigh = data.readUint8(13)
-        const logicalLow = data.readUint8(14)
-        return {
-            nodePos,
-            group,
-            logicalHigh,
-            logicalLow
-        }
-    }
-
-    // Set the MOST routing table, alloc result has to be present, it will the write the source1 data to
-    // that routing table, effectively streaming on the network
-    setMrtSource1(
-        {sourceAddrHigh,
-        sourceAddrLow,
+  sendControlMessage(
+    {
+      targetAddressHigh,
+      targetAddressLow,
+      fBlockID,
+      instanceID,
+      fktId,
+      opType,
+      data,
+    }: SocketMostSendMessage,
+    telId = 0,
+  ): void {
+    if (data.length > 12) {
+      this.multiPartMessage = {
+        targetAddressHigh,
+        targetAddressLow,
         fBlockID,
         instanceID,
-        sinkNr}: Stream
-    ): void {
-        console.log("setting mrt")
-        if (this.allocResult!.loc1 > -1) {
-            console.log("mrt running", this.allocResult)
-            this.writeReg(this.allocResult!.loc1, [0x49])
-            this.writeReg(this.allocResult!.loc2, [0x59])
-            this.writeReg(this.allocResult!.loc3, [0x69])
-            this.writeReg(this.allocResult!.loc4, [0x79])
-            this.sendControlMessage({
-                //TODO need to align these types
-                targetAddressHigh: sourceAddrHigh,
-                targetAddressLow: sourceAddrLow,
-                fBlockID,
-                instanceID,
-                fktId: 0x112,
-                opType: 0x02,
-                data: [sinkNr]
-            })
-            setTimeout(() => {
-                console.log("connecting target to sink")
-                this.connectSink({sourceAddrHigh, sourceAddrLow, fBlockID, instanceID, sinkNr})
-                this.writeReg(Registers.REG_bSDC3, [0x00])
-                this.writeReg(Registers.REG_bSDC1, [
-                    this.readSingleReg(Registers.REG_bSDC1) | Registers.bSDC1_UNMUTE_SOURCE
-                ])
-                console.log(this.readSingleReg(Registers.REG_bSDC1))
-                console.log(this.readSingleReg(Registers.REG_bSDC2))
-                console.log(this.readSingleReg(Registers.REG_bSDC3))
-                // await this.sourceDataControl3.setMultiple({mute: false, sourceEnable: false})
-                // await this.sourceDataControl1.setMultiple({mute: true})
-            }, 100)
-        }
+        fktId,
+        opType,
+        data: [...data],
+      }
+      this.multiPartSequence = 0
+      this.sendMultiPartMessage()
+    } else {
+      if (this.transceiverLocked) {
+        const header = Buffer.alloc(9)
+        header.writeUInt8(0x01, 0)
+        header.writeUInt8(0x00, 1)
+        header.writeUInt8(targetAddressHigh, 2)
+        header.writeUInt8(targetAddressLow, 3)
+        header.writeUInt8(fBlockID, 4)
+        header.writeUInt8(instanceID, 5)
+        header.writeUInt16BE((fktId << 4) | opType, 6)
+        header.writeUInt8(telId | data.length, 8)
+        const buf = Buffer.alloc(21)
+        const tempData = Buffer.concat([header, Buffer.from(data)])
+        tempData.copy(buf, 0, 0, tempData.length)
+        this.writeReg(0xc0, [...buf])
+        this.writeReg(Registers.REG_bMSGC, [
+          this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_START_TX,
+        ])
+      } else {
+        console.log("CAN'T SEND NO LOCK")
+      }
     }
+  }
 
-    setMrtSink1(bytes: number[]): void {
-        console.log("setting mrt", bytes)
-        if (bytes.length > 2) {
-            this.writeReg(0x46, [bytes[0]])
-            this.writeReg(0x56, [bytes[1]])
-            this.writeReg(0x66, [bytes[2]])
-            this.writeReg(0x76, [bytes[3]])
-        } else {
-            this.writeReg(0x46, [bytes[0]])
-            this.writeReg(0x56, [bytes[1]])
-            this.writeReg(0x66, [bytes[0]])
-            this.writeReg(0x76, [bytes[1]])
-        }
-        // TODO duplicated from mrtSource, needs to move both to a separate function, not needed either if already un-muted
-        setTimeout(() => {
-            this.writeReg(Registers.REG_bSDC3, [0x00])
-            this.writeReg(Registers.REG_bSDC1, [
-                this.readSingleReg(Registers.REG_bSDC1) | Registers.bSDC1_UNMUTE_SOURCE
-            ])
-            console.log(this.readSingleReg(Registers.REG_bSDC1))
-            console.log(this.readSingleReg(Registers.REG_bSDC2))
-            console.log(this.readSingleReg(Registers.REG_bSDC3))
-            // await this.sourceDataControl3.setMultiple({mute: false, sourceEnable: false})
-            // await this.sourceDataControl1.setMultiple({mute: true})
-        }, 100)
+  sendMultiPartMessage(): void {
+    const tempMessage = { ...this.multiPartMessage! }
+    this.multiPartMessage!.data.length > 11
+      ? (tempMessage.data = this.multiPartMessage!.data.splice(0, 11))
+      : (tempMessage.data = this.multiPartMessage!.data)
+    tempMessage.data = [this.multiPartSequence, ...tempMessage.data]
+    let telId
+    // In a multipart message telId represents the beginning, middle and end of the message, telId = 1 means first message, telId = 2 means message continuing
+    // telId = 3 means final message
+    if (this.multiPartSequence === 0) {
+      telId = 1
+    } else if (this.multiPartMessage!.data.length < 11) {
+      telId = 3
+    } else {
+      telId = 2
     }
+    this.sendControlMessage(tempMessage, telId)
+    if (telId !== 3) {
+      this.once('messageSent', () => {
+        this.multiPartSequence += 1
+        this.sendMultiPartMessage()
+      })
+    }
+  }
 
-    connectSink(
-        {
-            sourceAddrHigh,
-            sourceAddrLow,
-            fBlockID,
-            instanceID,
-            sinkNr
-    }: Stream
-    ): void {
-        // TODO make srcDelay dynamic, unsure of impact
-        const data = [
-            sinkNr,
-            3,
-            this.allocResult!.loc1,
-            this.allocResult!.loc2,
-            this.allocResult!.loc3,
-            this.allocResult!.loc4
-        ] // data format is [sinkNumber, srcDelay, channelList]
+  getNodePosition(): number {
+    return this.readSingleReg(Registers.REG_bNPR)
+  }
 
-        this.sendControlMessage({
-            targetAddressHigh: sourceAddrHigh,
-            targetAddressLow: sourceAddrLow,
-            fBlockID,
-            instanceID,
-            fktId: 0x111,
-            opType: 0x02,
-            data
+  getMaxPosition(): number {
+    return this.readSingleReg(Registers.REG_bMPR)
+  }
+
+  allocate(): void {
+    const header = Buffer.alloc(7)
+    header.writeUInt8(0x01, 0)
+    header.writeUInt8(0x03, 1)
+    header.writeUInt8(0x04, 2)
+    header.writeUInt8(0x00, 3)
+    header.writeUInt8(0x00, 4)
+    header.writeUInt8(0x04, 5)
+    header.writeUInt8(0x00, 6)
+    this.writeReg(0xc0, [...header])
+    this.writeReg(Registers.REG_bMSGC, [
+      this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_START_TX,
+    ])
+    this.awaitAlloc = true
+    this.allocTimeout = setTimeout(() => {
+      this.awaitAlloc = false
+      console.log('ALLOCATE TIMEOUT')
+    }, 500)
+  }
+
+  getRemoteSource(connectionLabel: number): void {
+    const header = Buffer.alloc(7)
+    header.writeUInt8(0x01, 0)
+    header.writeUInt8(0x05, 1)
+    header.writeUInt8(0x03, 2)
+    header.writeUInt8(0xc8, 3)
+    header.writeUInt8(0x00, 4)
+    header.writeUInt8(connectionLabel, 5)
+    header.writeUInt8(0x00, 6)
+    this.writeReg(0xc0, [...header])
+    this.writeReg(Registers.REG_bMSGC, [
+      this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_START_TX,
+    ])
+    this.awaitGetSource = true
+    this.getSourceTimeout = setTimeout(() => {
+      this.awaitGetSource = false
+      console.log('Remote TIMEOUT')
+    }, 500)
+  }
+
+  checkForLock(): void {
+    const lockStatus = this.readSingleReg(Registers.REG_bCM2)
+    const pllLocked = lockStatus & Registers.bCM2_UNLOCKED
+    const lockSource =
+      this.readSingleReg(Registers.REG_bXSR) & Registers.bXSR_FREQ_REG_ACT
+    if (pllLocked === 0 && lockSource === 0) {
+      this.emit(Os8104Events.Locked)
+      this.writeReg(Registers.REG_bMSGC, [
+        this.readSingleReg(Registers.REG_bMSGC) | Registers.bMSGC_RESET_ERR_INT,
+      ])
+      this.transceiverLocked = true
+      clearInterval(this.lockInterval)
+    }
+  }
+
+  parseAllocateResponse(data: Buffer): AllocResult {
+    const answer1 = data.readUint8(7)
+    const answer2 = data.readUint8(8)
+    const cl = data.readUint8(9)
+    const loc1 = data.readUint8(9)
+    const loc2 = data.readUint8(10)
+    const loc3 = data.readUint8(11)
+    const loc4 = data.readUint8(12)
+    const result: AllocResult = {
+      loc1,
+      loc2,
+      loc3,
+      loc4,
+      cl,
+    }
+    switch (answer1) {
+      case 1:
+        result.answer1 = 'ALLOC_GRANT'
+        result.freeChannels = answer2
+        break
+      case 2:
+        result.answer1 = 'ALLOC_BUSY'
+        result.freeChannels = answer2
+        break
+      case 3:
+        result.answer1 = 'ALLOC_DENY'
+        result.freeChannels = answer2
+        break
+      case 4:
+        result.answer1 = 'WRONG_TARGET'
+        result.freeChannels = answer2
+        break
+      default:
+        result.answer1 = 'ERROR'
+        result.freeChannels = 0
+    }
+    return result
+  }
+
+  stream({
+    sourceAddrHigh,
+    sourceAddrLow,
+    fBlockID,
+    instanceID,
+    sinkNr,
+  }: Stream): void {
+    this.allocResult = {
+      loc1: -1,
+      loc2: -1,
+      loc3: -1,
+      loc4: -1,
+      cl: -1,
+    }
+    this.allocate()
+    this.waitForAlloc(
+      sourceAddrHigh,
+      sourceAddrLow,
+      fBlockID,
+      instanceID,
+      sinkNr,
+    )
+  }
+
+  retrieveAudio(bytes: {
+    '0': number
+    '1': number
+    '2'?: number
+    '3'?: number
+  }): void {
+    console.log('retrieve audio in os8104', bytes)
+    const bytesT: number[] = []
+    bytesT.push(bytes['0'])
+    bytesT.push(bytes['1'])
+    if (bytes['2'] !== undefined) {
+      bytesT.push(bytes['2'])
+    }
+    if (bytes['3'] !== undefined) {
+      bytesT.push(bytes['3'])
+    }
+    this.setMrtSink1(bytesT)
+  }
+
+  waitForAlloc(
+    sourceAddrHigh: number,
+    sourceAddrLow: number,
+    fBlockID: number,
+    instanceID: number,
+    sinkNr: number,
+  ): void {
+    this.allocCheck = setInterval(() => {
+      if (this.allocResult !== null) {
+        console.log('alloc done, setting MRT')
+        clearTimeout(this.streamAllocTimeout)
+        clearInterval(this.allocCheck)
+        this.setMrtSource1({
+          sourceAddrHigh,
+          sourceAddrLow,
+          fBlockID,
+          instanceID,
+          sinkNr,
         })
-    }
+      }
+    }, 20)
+    this.streamAllocTimeout = setTimeout(() => {
+      clearInterval(this.allocCheck)
+      console.log('stream audio timed out on alloc check')
+    }, 1000)
+  }
 
-    getMode(): void {
-        const mode = this.readSingleReg(Registers.REG_bCM3) & Registers.bCM3_ENH
-        console.log("mode", mode)
+  parseRemoteGetSource(data: Buffer): SourceResult {
+    const nodePos = data.readUint8(10)
+    const group = data.readUint8(12)
+    const logicalHigh = data.readUint8(13)
+    const logicalLow = data.readUint8(14)
+    return {
+      nodePos,
+      group,
+      logicalHigh,
+      logicalLow,
     }
+  }
+
+  // Set the MOST routing table, alloc result has to be present, it will the write the source1 data to
+  // that routing table, effectively streaming on the network
+  setMrtSource1({
+    sourceAddrHigh,
+    sourceAddrLow,
+    fBlockID,
+    instanceID,
+    sinkNr,
+  }: Stream): void {
+    console.log('setting mrt')
+    if (this.allocResult!.loc1 > -1) {
+      console.log('mrt running', this.allocResult)
+      this.writeReg(this.allocResult!.loc1, [0x49])
+      this.writeReg(this.allocResult!.loc2, [0x59])
+      this.writeReg(this.allocResult!.loc3, [0x69])
+      this.writeReg(this.allocResult!.loc4, [0x79])
+      this.sendControlMessage({
+        //TODO need to align these types
+        targetAddressHigh: sourceAddrHigh,
+        targetAddressLow: sourceAddrLow,
+        fBlockID,
+        instanceID,
+        fktId: 0x112,
+        opType: 0x02,
+        data: [sinkNr],
+      })
+      setTimeout(() => {
+        console.log('connecting target to sink')
+        this.connectSink({
+          sourceAddrHigh,
+          sourceAddrLow,
+          fBlockID,
+          instanceID,
+          sinkNr,
+        })
+        this.writeReg(Registers.REG_bSDC3, [0x00])
+        this.writeReg(Registers.REG_bSDC1, [
+          this.readSingleReg(Registers.REG_bSDC1) |
+            Registers.bSDC1_UNMUTE_SOURCE,
+        ])
+        console.log(this.readSingleReg(Registers.REG_bSDC1))
+        console.log(this.readSingleReg(Registers.REG_bSDC2))
+        console.log(this.readSingleReg(Registers.REG_bSDC3))
+        // await this.sourceDataControl3.setMultiple({mute: false, sourceEnable: false})
+        // await this.sourceDataControl1.setMultiple({mute: true})
+      }, 100)
+    }
+  }
+
+  setMrtSink1(bytes: number[]): void {
+    console.log('setting mrt', bytes)
+    if (bytes.length > 2) {
+      this.writeReg(0x46, [bytes[0]])
+      this.writeReg(0x56, [bytes[1]])
+      this.writeReg(0x66, [bytes[2]])
+      this.writeReg(0x76, [bytes[3]])
+    } else {
+      this.writeReg(0x46, [bytes[0]])
+      this.writeReg(0x56, [bytes[1]])
+      this.writeReg(0x66, [bytes[0]])
+      this.writeReg(0x76, [bytes[1]])
+    }
+    // TODO duplicated from mrtSource, needs to move both to a separate function, not needed either if already un-muted
+    setTimeout(() => {
+      this.writeReg(Registers.REG_bSDC3, [0x00])
+      this.writeReg(Registers.REG_bSDC1, [
+        this.readSingleReg(Registers.REG_bSDC1) | Registers.bSDC1_UNMUTE_SOURCE,
+      ])
+      console.log(this.readSingleReg(Registers.REG_bSDC1))
+      console.log(this.readSingleReg(Registers.REG_bSDC2))
+      console.log(this.readSingleReg(Registers.REG_bSDC3))
+      // await this.sourceDataControl3.setMultiple({mute: false, sourceEnable: false})
+      // await this.sourceDataControl1.setMultiple({mute: true})
+    }, 100)
+  }
+
+  connectSink({
+    sourceAddrHigh,
+    sourceAddrLow,
+    fBlockID,
+    instanceID,
+    sinkNr,
+  }: Stream): void {
+    // TODO make srcDelay dynamic, unsure of impact
+    const data = [
+      sinkNr,
+      3,
+      this.allocResult!.loc1,
+      this.allocResult!.loc2,
+      this.allocResult!.loc3,
+      this.allocResult!.loc4,
+    ] // data format is [sinkNumber, srcDelay, channelList]
+
+    this.sendControlMessage({
+      targetAddressHigh: sourceAddrHigh,
+      targetAddressLow: sourceAddrLow,
+      fBlockID,
+      instanceID,
+      fktId: 0x111,
+      opType: 0x02,
+      data,
+    })
+  }
+
+  getMode(): void {
+    const mode = this.readSingleReg(Registers.REG_bCM3) & Registers.bCM3_ENH
+    console.log('mode', mode)
+  }
 }

--- a/src/driver/Registers.ts
+++ b/src/driver/Registers.ts
@@ -1,215 +1,216 @@
 export enum Registers {
-    // Registers
-    REG_bXCR = 0x80,
-    REG_bXSR = 0x81,
-    REG_bSDC1 = 0x82,
-    REG_bCM1 = 0x83,
-    REG_bNC = 0x84,
-    REG_bMSGC = 0x85,
-    REG_bMSGS = 0x86,
-    REG_bNPR = 0x87,
-    REG_bIE = 0x88,
-    REG_bGA = 0x89,
-    REG_bNAH = 0x8a,
-    REG_bNAL = 0x8b,
-    REG_bSDC2 = 0x8c,
-    REG_bSDC3 = 0x8d,
-    REG_bCM2 = 0x8e,
-    REG_bNDR = 0x8f,
-    REG_bMPR = 0x90,
-    REG_bMDR = 0x91,
-    REG_bCM3 = 0x92,
-    REG_bCM4 = 0x93,
-    REG_bFRHL = 0x94,
-    REG_bFRLO = 0x95,
-    REG_bSBC = 0x96,
-    REG_bXSR2 = 0x97,
-    REG_mRCMB = 0xa0,
-    REG_bXTIM = 0xbe,
-    REG_bXRTY = 0xbf,
-    REG_mXCMB = 0xc0,
-    REG_bXTS = 0xd5,
-    REG_bPCTC = 0xe2,
-    REG_bPCTS = 0xe3,
-    REG_bAPAH = 0xe8,
-    REG_bAPAL = 0xe9,
-    REG_bPSTX = 0xea,
-    REG_bPLDT = 0xec,
-    REG_bPPI = 0xf2,
-    REG_mARP = 0x180,
-    REG_mAXP = 0x1c0,
-    REG_bXLRTY = 0x3c0,
-    REG_bXSTIM = 0x3c1,
+  // Registers
+  REG_bXCR = 0x80,
+  REG_bXSR = 0x81,
+  REG_bSDC1 = 0x82,
+  REG_bCM1 = 0x83,
+  REG_bNC = 0x84,
+  REG_bMSGC = 0x85,
+  REG_bMSGS = 0x86,
+  REG_bNPR = 0x87,
+  REG_bIE = 0x88,
+  REG_bGA = 0x89,
+  REG_bNAH = 0x8a,
+  REG_bNAL = 0x8b,
+  REG_bSDC2 = 0x8c,
+  REG_bSDC3 = 0x8d,
+  REG_bCM2 = 0x8e,
+  REG_bNDR = 0x8f,
+  REG_bMPR = 0x90,
+  REG_bMDR = 0x91,
+  REG_bCM3 = 0x92,
+  REG_bCM4 = 0x93,
+  REG_bFRHL = 0x94,
+  REG_bFRLO = 0x95,
+  REG_bSBC = 0x96,
+  REG_bXSR2 = 0x97,
+  REG_mRCMB = 0xa0,
+  REG_bXTIM = 0xbe,
+  REG_bXRTY = 0xbf,
+  REG_mXCMB = 0xc0,
+  REG_bXTS = 0xd5,
+  REG_bPCTC = 0xe2,
+  REG_bPCTS = 0xe3,
+  REG_bAPAH = 0xe8,
+  REG_bAPAL = 0xe9,
+  REG_bPSTX = 0xea,
+  REG_bPLDT = 0xec,
+  REG_bPPI = 0xf2,
+  REG_mARP = 0x180,
+  REG_mAXP = 0x1c0,
+  REG_bXLRTY = 0x3c0,
+  REG_bXSTIM = 0x3c1,
 
-    // Register bXCR Transceiver Control Register 0x80
-    bXCR_MASTER = 0x80,
-    bXCR_SLAVE = 0x00, // Default
+  // Register bXCR Transceiver Control Register 0x80
+  bXCR_MASTER = 0x80,
+  bXCR_SLAVE = 0x00, // Default
 
-    bXCR_OUTPUT_ENABLE = 0x40,
-    bXCR_OUTPUT_DISABLE = 0x00, // Default
+  bXCR_OUTPUT_ENABLE = 0x40,
+  bXCR_OUTPUT_DISABLE = 0x00, // Default
 
-    bXCR_LEGACY_BYPASS = 0x20,
-    bXCR_ENHANCED_BYPASS = 0x00,
+  bXCR_LEGACY_BYPASS = 0x20,
+  bXCR_ENHANCED_BYPASS = 0x00,
 
-    bXCR_LOWPOWER_WAKE_EN = 0x00, // Default
-    bXCR_LOWPOWER_WAKE_DIS = 0x10,
+  bXCR_LOWPOWER_WAKE_EN = 0x00, // Default
+  bXCR_LOWPOWER_WAKE_DIS = 0x10,
 
-    bXCR_STANDALONE_EN = 0x08,
-    bXCR_STANDALONE_DIS = 0x00, // Default
+  bXCR_STANDALONE_EN = 0x08,
+  bXCR_STANDALONE_DIS = 0x00, // Default
 
-    bXCR_SOURCE_BYPASS_DIS = 0x00, // Default
-    bXCR_SOURCE_BYPASS_EN = 0x04,
+  bXCR_SOURCE_BYPASS_DIS = 0x00, // Default
+  bXCR_SOURCE_BYPASS_EN = 0x04,
 
-    bXCR_ALL_BYPASS_EN = 0x00,
-    bXCR_ALL_BYPASS_DIS = 0x02,
+  bXCR_ALL_BYPASS_EN = 0x00,
+  bXCR_ALL_BYPASS_DIS = 0x02,
 
-    bXCR_REN_EN = 0x00, // Default
-    bXCR_REN_DIS = 0x01,
+  bXCR_REN_EN = 0x00, // Default
+  bXCR_REN_DIS = 0x01,
 
-    // Register bXSR Transceiver Status Register 0x81
-    bXSR_FREQ_REG_ACT = 0x80,
-    bXSR_FREQ_REG_INACT = 0x00,
+  // Register bXSR Transceiver Status Register 0x81
+  bXSR_FREQ_REG_ACT = 0x80,
+  bXSR_FREQ_REG_INACT = 0x00,
 
-    bXSR_SPDIF_ERR_MASK = 0x40, // Default
-    bXSR_SPDIF_ERR_EN = 0x00,
+  bXSR_SPDIF_ERR_MASK = 0x40, // Default
+  bXSR_SPDIF_ERR_EN = 0x00,
 
-    bXSR_LOCK_ERR_MASK = 0x20,
-    bXSR_LOCK_ERR_EN = 0x00, // Default
+  bXSR_LOCK_ERR_MASK = 0x20,
+  bXSR_LOCK_ERR_EN = 0x00, // Default
 
-    bXSR_CODING_ERR_MASK = 0x10, // Default
-    bXSR_CODING_ERR_EN = 0x00,
+  bXSR_CODING_ERR_MASK = 0x10, // Default
+  bXSR_CODING_ERR_EN = 0x00,
 
-    bXSR_ERR_ACT = 0x08,
-    bXSR_ERR_CLR = 0x00,
+  bXSR_ERR_ACT = 0x08,
+  bXSR_ERR_CLR = 0x00,
 
-    bXSR_FREQ_REG_LOCKED = 0x04,
-    bXSR_FREQ_REG_UNLOCKED = 0x00,
+  bXSR_FREQ_REG_LOCKED = 0x04,
+  bXSR_FREQ_REG_UNLOCKED = 0x00,
 
-    bXSR_SPDIF_LOCK_ACT = 0x02,
-    bXSR_SPDIF_LOCK_INACT = 0x00,
+  bXSR_SPDIF_LOCK_ACT = 0x02,
+  bXSR_SPDIF_LOCK_INACT = 0x00,
 
-    bXSR_TRANS_LOCK_ACT = 0x01,
-    bXSR_TRANS_LOCK_INACT = 0x00,
+  bXSR_TRANS_LOCK_ACT = 0x01,
+  bXSR_TRANS_LOCK_INACT = 0x00,
 
-    // Register bSDC1 Source Data Control Register 0x82
-    bSDC1_ACTIVE_EDGE_EN = 0x80,
-    bSDC1_ACTIVE_EDGE_DIS = 0x00,
+  // Register bSDC1 Source Data Control Register 0x82
+  bSDC1_ACTIVE_EDGE_EN = 0x80,
+  bSDC1_ACTIVE_EDGE_DIS = 0x00,
 
-    bSDC1_DELAY_FIRST_BIT_EN = 0x40,
-    bSDC1_DELAY_FIRST_BIT_DIS = 0x00,
+  bSDC1_DELAY_FIRST_BIT_EN = 0x40,
+  bSDC1_DELAY_FIRST_BIT_DIS = 0x00,
 
-    bSDC1_POLARITY_FSY_RISING = 0x20,
-    bSDC1_POLARITY_FSY_FALLING = 0x00,
+  bSDC1_POLARITY_FSY_RISING = 0x20,
+  bSDC1_POLARITY_FSY_FALLING = 0x00,
 
-    bSDC1_SCK_OUTPUT = 0x10,
-    bSDC1_SCK_INPUT = 0x00,
+  bSDC1_SCK_OUTPUT = 0x10,
+  bSDC1_SCK_INPUT = 0x00,
 
-    bSDC1_NO_CYCLES_DEF = 0x00,
-    bSDC1_NO_CYCLES_DIV = 0x08,
+  bSDC1_NO_CYCLES_DEF = 0x00,
+  bSDC1_NO_CYCLES_DIV = 0x08,
 
-    bSDC1_SPDIF_EN = 0x04,
-    bSDC1_SPDIF_DIS = 0x00,
+  bSDC1_SPDIF_EN = 0x04,
+  bSDC1_SPDIF_DIS = 0x00,
 
-    bSDC1_MUTE_SOURCE = 0x00,
-    bSDC1_UNMUTE_SOURCE = 0x02,
+  bSDC1_MUTE_SOURCE = 0x00,
+  bSDC1_UNMUTE_SOURCE = 0x02,
 
-    bSDC1_TRANSPARENT_EN = 0x00,
-    bSDC1_TRANSPARENT_DIS = 0x01,
+  bSDC1_TRANSPARENT_EN = 0x00,
+  bSDC1_TRANSPARENT_DIS = 0x01,
 
-    // Register bCM1 Clock Manager 1 0x83
-    bCM1_PLL_DISABLE = 0x80,
-    bCM1_PLL_ENABLE = 0x00,
+  // Register bCM1 Clock Manager 1 0x83
+  bCM1_PLL_DISABLE = 0x80,
+  bCM1_PLL_ENABLE = 0x00,
 
-    bCM1_RMCK_DIV_384F = 0x00, // Default
-    bCM1_RMCK_DIV_256F = 0x10,
-    bCM1_RMCK_DIV_128F = 0x20,
-    bCM1_RMCK_DIV_64F = 0x30,
-    bCM1_RMCK_DIV_1536F = 0x40,
-    bCM1_RMCK_DIV_1024F = 0x50,
-    bCM1_RMCK_DIV_768F = 0x60,
-    bCM1_RMCK_DIV_512F = 0x70,
+  bCM1_RMCK_DIV_384F = 0x00, // Default
+  bCM1_RMCK_DIV_256F = 0x10,
+  bCM1_RMCK_DIV_128F = 0x20,
+  bCM1_RMCK_DIV_64F = 0x30,
+  bCM1_RMCK_DIV_1536F = 0x40,
+  bCM1_RMCK_DIV_1024F = 0x50,
+  bCM1_RMCK_DIV_768F = 0x60,
+  bCM1_RMCK_DIV_512F = 0x70,
 
-    bCM1_CRYSTAL_DIVIDER_256F = 0x00,
-    bCM1_CRYSTAL_DIVIDER_384F = 0x04,
+  bCM1_CRYSTAL_DIVIDER_256F = 0x00,
+  bCM1_CRYSTAL_DIVIDER_384F = 0x04,
 
-    bCM1_PLL_INPUT_MOST = 0x00,
-    bCM1_PLL_INPUT_SR0 = 0x01,
-    bCM1_PLL_INPUT_CRYSTAL = 0x02,
-    bCM1_PLL_INPUT_SCK = 0x03,
+  // eslint-disable-next-line @typescript-eslint/no-duplicate-enum-values
+  bCM1_PLL_INPUT_MOST = 0x00,
+  bCM1_PLL_INPUT_SR0 = 0x01,
+  bCM1_PLL_INPUT_CRYSTAL = 0x02,
+  bCM1_PLL_INPUT_SCK = 0x03,
 
-    // Register bMSGC Message Control Register 0x85
-    bMSGC_START_TX = 0x80,
-    bMSGC_STOP_TX = 0x00,
+  // Register bMSGC Message Control Register 0x85
+  bMSGC_START_TX = 0x80,
+  bMSGC_STOP_TX = 0x00,
 
-    bMSGC_RECEIVE_BUFF_EN = 0x40,
-    bMSGC_RECEIVE_BUFF_DIS = 0x00,
+  bMSGC_RECEIVE_BUFF_EN = 0x40,
+  bMSGC_RECEIVE_BUFF_DIS = 0x00,
 
-    bMSGC_RESERVED = 0x00,
+  bMSGC_RESERVED = 0x00,
 
-    bMSGC_START_ADDRESS_INIT_EN = 0x10,
-    bMSGC_START_ADDRESS_INIT_DIS = 0x00,
+  bMSGC_START_ADDRESS_INIT_EN = 0x10,
+  bMSGC_START_ADDRESS_INIT_DIS = 0x00,
 
-    bMSGC_RESET_NET_CONF_CHANGE = 0x08,
+  bMSGC_RESET_NET_CONF_CHANGE = 0x08,
 
-    bMSGC_RESET_ERR_INT = 0x04,
+  bMSGC_RESET_ERR_INT = 0x04,
 
-    bMSGC_RESET_MESSAGE_TX_INT = 0x02,
+  bMSGC_RESET_MESSAGE_TX_INT = 0x02,
 
-    bMSGC_RESET_MESSAGE_RX_INT = 0x01,
+  bMSGC_RESET_MESSAGE_RX_INT = 0x01,
 
-    // Register bMSGS Message Status Register 0x86
-    bMSGS_RECEIVE_BUFF_STATUS_READY = 0x00,
-    bMSGS_RECEIVE_BUFF_STATUS_FULL = 0x80,
+  // Register bMSGS Message Status Register 0x86
+  bMSGS_RECEIVE_BUFF_STATUS_READY = 0x00,
+  bMSGS_RECEIVE_BUFF_STATUS_FULL = 0x80,
 
-    bMSGS_TRANS_SUCCESS = 0x40,
+  bMSGS_TRANS_SUCCESS = 0x40,
 
-    bMSGS_NET_CHANGED = 0x08,
+  bMSGS_NET_CHANGED = 0x08,
 
-    bMSGS_ERR = 0x04,
+  bMSGS_ERR = 0x04,
 
-    bMSGS_MESS_TRANSMITTED = 0x02,
+  bMSGS_MESS_TRANSMITTED = 0x02,
 
-    bMSGS_MESS_RECEIVED = 0x01,
+  bMSGS_MESS_RECEIVED = 0x01,
 
-    // Register bIE Interrupt Enable Register
-    bIE_NET_CHANGED_INT_EN = 0x08,
-    bIE_ERR_INT_EN = 0x04,
-    bIE_TX_INT_EN = 0x02,
-    bIE_RX_INT_EN = 0x01,
+  // Register bIE Interrupt Enable Register
+  bIE_NET_CHANGED_INT_EN = 0x08,
+  bIE_ERR_INT_EN = 0x04,
+  bIE_TX_INT_EN = 0x02,
+  bIE_RX_INT_EN = 0x01,
 
-    // Register source control 2
-    bSDC2_SCK_8F = 0x0,
-    bSDC2_SCK_16F = 0x20,
-    bSDC2_SCK_32F = 0x40,
-    bSDC2_SCK_64F = 0x60,
-    bSDC2_SCK_128F = 0x80,
-    bSDC2_SCK_256F = 0xa0,
+  // Register source control 2
+  bSDC2_SCK_8F = 0x0,
+  bSDC2_SCK_16F = 0x20,
+  bSDC2_SCK_32F = 0x40,
+  bSDC2_SCK_64F = 0x60,
+  bSDC2_SCK_128F = 0x80,
+  bSDC2_SCK_256F = 0xa0,
 
-    // Clock Manager 2
-    bCM2_UNLOCKED = 0x80,
-    BCM2_NETWORK_ACTIVITY = 0x40,
+  // Clock Manager 2
+  bCM2_UNLOCKED = 0x80,
+  BCM2_NETWORK_ACTIVITY = 0x40,
 
-    /// //Legacy testing/////
-    // bSDC3
-    bSDC3_MUTE_SOURCE_PORTS = 0x02,
-    bSDC3_UNMUTE_SOURCE_PORTS = 0x00,
+  /// //Legacy testing/////
+  // bSDC3
+  bSDC3_MUTE_SOURCE_PORTS = 0x02,
+  bSDC3_UNMUTE_SOURCE_PORTS = 0x00,
 
-    bSDC3_SOURCE_PORT_EN = 0x00,
-    bSDC3_SOURCE_PORT_DIS = 0x01,
+  bSDC3_SOURCE_PORT_EN = 0x00,
+  bSDC3_SOURCE_PORT_DIS = 0x01,
 
-    // bCM3
-    bCM3_FREN_EN = 0x10,
-    bCM3_FREN_DIS = 0x00,
+  // bCM3
+  bCM3_FREN_EN = 0x10,
+  bCM3_FREN_DIS = 0x00,
 
-    bCM3_ENH = 0x40,
+  bCM3_ENH = 0x40,
 
-    bCM3_AUTO_SWITCH_CLOCK = 0x08,
-    bCM3_DIS_AUTO_SWITCH_CLOCK = 0x00,
+  bCM3_AUTO_SWITCH_CLOCK = 0x08,
+  bCM3_DIS_AUTO_SWITCH_CLOCK = 0x00,
 
-    bCM3_AUTO_CRYSTAL_EN = 0x04,
-    bCM3_AUTO_CRYSTAL_DIS = 0x00,
+  bCM3_AUTO_CRYSTAL_EN = 0x04,
+  bCM3_AUTO_CRYSTAL_DIS = 0x00,
 
-    bCM3_FREQ_REG_RESET = 0x02
+  bCM3_FREQ_REG_RESET = 0x02,
 }
 
 export type Register = keyof typeof Registers

--- a/src/modules/Messages.ts
+++ b/src/modules/Messages.ts
@@ -1,159 +1,137 @@
-export type DriverConfig = {
-    version: string,
-    nodeAddress: number,
-    groupAddress: number,
-    freq: number
+export type MessageSource = {
+  sourceAddrHigh: number
+  sourceAddrLow: number
 }
 
-export type MessageDefault = {
-    sourceAddrHigh: number
-    sourceAddrLow: number
+export type MessageTarget = {
+  targetAddressHigh: number
+  targetAddressLow: number
 }
 
-export type MasterFoundEvent = MessageDefault & {
-    eventType: Os8104Events.MasterFoundEvent
-    instanceID: number
+export type MasterFoundEvent = MessageSource & {
+  eventType: Os8104Events.MasterFoundEvent
+  instanceID: number
 }
 
-export type newMessageEvent = MessageDefault & {
-    eventType: 'newMessage'
-    data: Buffer
+export type newMessageEvent = MessageSource & {
+  eventType: Os8104Events.SocketMostMessageRxEvent
+  data: Buffer
 }
 
-export type netChangedEvent = {
-    eventType: 'netChanged'
+export type MostMessage<T> = {
+  eventType?: string
+  fBlockID: number
+  instanceID: number
+  fktId: number
+  opType: number
+  data: T
 }
 
-export type shutDown = {
-    eventType: 'shutDown'
-}
+export type TargetMostMessage<T> = MostMessage<T> & MessageTarget
 
-export interface MostMessage {
-    eventType?: string
-    targetAddressHigh: number
-    targetAddressLow: number
-    fBlockID: number
-    instanceID: number
-    fktId: number
-    opType: number
-    data: number[]
-}
+export type SourceMostMessage<T> = MostMessage<T> & MessageSource
 
 //this is the message received over socket most with the event type attached
-export type SocketMostSendMessage = {
-    eventType?: string
-    targetAddressHigh: number
-    targetAddressLow: number
-    fBlockID: number
-    instanceID: number
-    fktId: number
-    opType: number
-    data: number[] | Buffer
-}
-
-// connectionLabel?: number
-// sinkNr?: number
+export type SocketMostSendMessage = TargetMostMessage<number[] | Buffer>
 
 export type RetrieveAudio = {
-    "0": number
-    "1": number
-    "2"?: number
-    "3"?: number
+  '0': number
+  '1': number
+  '2'?: number
+  '3'?: number
 }
 
-
-export type RawMostRxMessage = {
-    type: number
-    sourceAddrHigh: number
-    sourceAddrLow: number
-    fBlockID: number
-    instanceID: number
-    fktID: number
-    opType: number
-    telID: number
-    telLen: number
-    data: Buffer
-}
-
-export type SocketMostMessageRx = RawMostRxMessage &{
-    eventType: string
+export type MostRxMessage = SourceMostMessage<Buffer> & {
+  type: number
+  telID: number
+  telLen: number
 }
 
 export type Config = {
-    nodeAddressLow: number
-    nodeAddressHigh: number
-    groupAddress: number
+  nodeAddressLow: number
+  nodeAddressHigh: number
+  groupAddress: number
 }
 
 export type Stream = {
-    fBlockID: number
-    instanceID: number
-    sinkNr: number
-    sourceAddrHigh: number
-    sourceAddrLow: number
+  fBlockID: number
+  instanceID: number
+  sinkNr: number
+  sourceAddrHigh: number
+  sourceAddrLow: number
 }
 
 export type GetSource = {
-    connectionLabel: number
+  connectionLabel: number
 }
 
 export type AllocResult = {
-    loc1: number
-    loc2: number
-    loc3: number
-    loc4: number
-    cl: number
-    answer1?: "ALLOC_GRANT" | "ALLOC_BUSY" | "ALLOC_DENY" | "WRONG_TARGET" | "ERROR"
-    freeChannels?: number
+  loc1: number
+  loc2: number
+  loc3: number
+  loc4: number
+  cl: number
+  answer1?:
+    | 'ALLOC_GRANT'
+    | 'ALLOC_BUSY'
+    | 'ALLOC_DENY'
+    | 'WRONG_TARGET'
+    | 'ERROR'
+  freeChannels?: number
 }
 
 export type SourceResult = {
-    nodePos: number
-    group: number
-    logicalHigh: number
-    logicalLow: number
+  nodePos: number
+  group: number
+  logicalHigh: number
+  logicalLow: number
 }
 
 export type NodePosition = {
-    nodePosition: number
-    maxPosition: number
-    eventType: 'positionUpdate'
+  nodePosition: number
+  maxPosition: number
+  eventType: Os8104Events.PositionUpdate
 }
 
 export type newMessage = {
-    sourceAddressHigh: number
-    sourceAddressLow: number
+  sourceAddressHigh: number
+  sourceAddressLow: number
 }
 
 export type MessageOnly = {
-    eventType: 'locked' | 'unlocked' | 'shutDown' | 'messageSent' | 'getNodePosition'
+  eventType:
+    | Os8104Events.Locked
+    | Os8104Events.Unlocked
+    | Os8104Events.Shutdown
+    | Os8104Events.MessageSent
+    | SocketTypes.GetNodePosition
 }
 
 export enum Os8104Events {
-    MostMessageRx= "newMessageRx",
-    AllocResult= "allocResult",
-    GetSourceResult= "getSourceResult",
-    Unlocked= "unlocked",
-    Locked= "locked",
-    MessageSent= "messageSent",
-    Shutdown = "shutdown",
-    PositionUpdate = "positionUpdate",
-    MasterFoundEvent = 'masterFound',
-    SocketMostMessageRxEvent = 'newMessage'
+  MostMessageRx = 'newMessageRx',
+  AllocResult = 'allocResult',
+  GetSourceResult = 'getSourceResult',
+  Unlocked = 'unlocked',
+  Locked = 'locked',
+  MessageSent = 'messageSent',
+  Shutdown = 'shutdown',
+  PositionUpdate = 'positionUpdate',
+  MasterFoundEvent = 'masterFound',
+  SocketMostMessageRxEvent = 'newMessage',
 }
 
 export enum SocketTypes {
-    MessageReceived= 'message',
-    SendControlMessage= 'sendControlMessage',
-    GetNodePosition= 'getNodePosition',
-    GetMaster= 'getMaster',
-    Allocate= 'allocate',
-    GetSource= 'getSource',
-    Stream= 'stream',
-    RetrieveAudio= 'retrieveAudio'
+  MessageReceived = 'message',
+  SendControlMessage = 'sendControlMessage',
+  GetNodePosition = 'getNodePosition',
+  GetMaster = 'getMaster',
+  Allocate = 'allocate',
+  GetSource = 'getSource',
+  Stream = 'stream',
+  RetrieveAudio = 'retrieveAudio',
 }
 
 export enum Mode {
-    leg = 0,
-    enh = 1
+  leg = 0,
+  enh = 1,
 }

--- a/src/server/SocketMost.ts
+++ b/src/server/SocketMost.ts
@@ -2,170 +2,192 @@ import fs from 'fs'
 import unix from 'unix-dgram'
 import { OS8104A } from '../driver/OS8104A'
 import {
-    AllocResult, Config, DriverConfig,
-    GetSource,
-    MasterFoundEvent,
-    MessageOnly,
-    MostMessage,
-    NodePosition,
-    Os8104Events,
-    RawMostRxMessage,
-    RetrieveAudio,
-    SocketMostMessageRx,
-    SocketTypes,
-    Stream
+  AllocResult,
+  GetSource,
+  MasterFoundEvent,
+  MessageOnly,
+  NodePosition,
+  Os8104Events,
+  MostRxMessage,
+  RetrieveAudio,
+  SocketMostSendMessage,
+  SocketTypes,
+  Stream,
 } from '../modules/Messages'
 
+export type DriverConfig = {
+  version: string
+  nodeAddress: number
+  groupAddress: number
+  freq: number
+}
+
 const DEFAULT_CONFIG: DriverConfig = {
-    version: '1.0.0',
-    nodeAddress: 272,
-    groupAddress: 34,
-    freq: 48
+  version: '1.0.0',
+  nodeAddress: 272,
+  groupAddress: 34,
+  freq: 48,
 }
 
 export class SocketMost {
-    configPath: string
-    config: DriverConfig
-    connected: boolean
-    connectInterval?: NodeJS.Timer
-    master?: MasterFoundEvent
-    udpSocket?
-    os8104: OS8104A
+  configPath: string
+  config: DriverConfig
+  connected: boolean
+  connectInterval?: NodeJS.Timer
+  master?: MasterFoundEvent
+  udpSocket?
+  os8104: OS8104A
 
-    constructor() {
-        this.configPath = './config.json'
-        this.config = DEFAULT_CONFIG
+  constructor() {
+    this.configPath = './config.json'
+    this.config = DEFAULT_CONFIG
+    this.connected = false
+    this.udpSocket = new unix.createSocket('unix_dgram', () => {
+      if (fs.existsSync(this.configPath)) {
+        console.log('file exists')
+        this.config = JSON.parse(fs.readFileSync(this.configPath).toString())
+        console.log(this.config)
+      } else {
+        fs.writeFileSync(this.configPath, JSON.stringify(DEFAULT_CONFIG))
+      }
+    })
+    this.udpSocket.on('error', () => {
+      if (this.connected) {
         this.connected = false
-        this.udpSocket = new unix.createSocket('unix_dgram', () => {
-            if (fs.existsSync(this.configPath)) {
-                console.log('file exists')
-                this.config = JSON.parse(fs.readFileSync(this.configPath).toString())
-                console.log(this.config)
-            } else {
-                fs.writeFileSync(this.configPath, JSON.stringify(DEFAULT_CONFIG))
-            }
-        })
-        this.udpSocket.on('error', () => {
-            if (this.connected) {
-                this.connected = false
-                this.connectInterval = setInterval(() => {
-                    this.udpSocket.connect('/tmp/SocketMost-client.sock')
-                }, 100)
-            }
-        })
+        this.connectInterval = setInterval(() => {
+          this.udpSocket.connect('/tmp/SocketMost-client.sock')
+        }, 100)
+      }
+    })
 
-        this.udpSocket.on(SocketTypes.MessageReceived, async (data: Buffer) => {
-            const event: SocketTypes = JSON.parse(data.toString()).eventType
-            switch (event) {
-                case SocketTypes.SendControlMessage: {
-                    //console.log("sending", message)
-                    const message: MostMessage = JSON.parse(data.toString());
-                    this.os8104.sendControlMessage(message)
-                    // TODO is this really needed? sendControlMessage doesn't return and is not async, so in what case is this
-                    //  actually required? No types set for now as suspect it needs to go
-                    this.udpSocket.send(Buffer.from(JSON.stringify({eventType: 'messageSent'})))
-                    break
-                }
-                case SocketTypes.GetNodePosition: {
-                    const returnData: NodePosition = {
-                        nodePosition: this.os8104.getNodePosition(),
-                        maxPosition: this.os8104.getMaxPosition(),
-                        eventType: Os8104Events.PositionUpdate
-                    }
-                    // REVIEW This is strange, NodePosition is not stated as a type for streamSend so unsure why no error here
-                    //  my guess is that it unions the same MessageDefault as the other typed streamSends (MasterFoundEvent, newMessage)
-                    //  which then makes me think there's something grossly incorrect here, leaving for now for review purposes
-                    this.streamSend(returnData)
-                    break
-                }
-                case SocketTypes.GetMaster: {
-                    if (this.master) {
-                        this.streamSend(this.master)
-                    }
-                    break
-                }
-                case SocketTypes.Allocate:
-                    console.log("awaited", this.os8104.allocate())
-                    break
-                case SocketTypes.GetSource: {
-                    const message: GetSource = JSON.parse(data.toString());
-                    // REVIEW don't particularly like this, had to add connection label as a chained property solely for this
-                    //  call, need to look into alternatives, it feels like using an outer type (MostMessage in this case)
-                    //  for a switch statement is not ideal
-                    this.os8104.getRemoteSource(message.connectionLabel!)
-                    break
-                }
-                case SocketTypes.Stream: {
-                    const message: Stream = JSON.parse(data.toString());
-                    this.os8104.stream(message)
-                    break
-                }
-                case SocketTypes.RetrieveAudio: {
-                    // TODO remove numbers from key in message
-                    const message: RetrieveAudio = JSON.parse(data.toString());
-                    this.os8104.retrieveAudio(message)
-                }
-            }
-        });
-
-        try {
-            fs.unlinkSync('/tmp/SocketMost.sock');
-        } catch (e) { /* swallow */
+    this.udpSocket.on(SocketTypes.MessageReceived, async (data: Buffer) => {
+      const event: SocketTypes = JSON.parse(data.toString()).eventType
+      switch (event) {
+        case SocketTypes.SendControlMessage: {
+          //console.log("sending", message)
+          const message: SocketMostSendMessage = JSON.parse(data.toString())
+          this.os8104.sendControlMessage(message)
+          // TODO is this really needed? sendControlMessage doesn't return and is not async, so in what case is this
+          //  actually required? No types set for now as suspect it needs to go
+          this.udpSocket.send(
+            Buffer.from(JSON.stringify({ eventType: 'messageSent' })),
+          )
+          break
         }
-        this.udpSocket.bind('/tmp/SocketMost.sock');
-        this.connectInterval = setInterval(() => this.udpSocket.connect('/tmp/SocketMost-client.sock'), 100)
-        this.os8104 = new OS8104A(this.config.nodeAddress, this.config.groupAddress, this.config.freq)
+        case SocketTypes.GetNodePosition: {
+          const returnData: NodePosition = {
+            nodePosition: this.os8104.getNodePosition(),
+            maxPosition: this.os8104.getMaxPosition(),
+            eventType: Os8104Events.PositionUpdate,
+          }
+          // REVIEW This is strange, NodePosition is not stated as a type for streamSend so unsure why no error here
+          //  my guess is that it unions the same MessageDefault as the other typed streamSends (MasterFoundEvent, newMessage)
+          //  which then makes me think there's something grossly incorrect here, leaving for now for review purposes
+          this.streamSend(returnData)
+          break
+        }
+        case SocketTypes.GetMaster: {
+          if (this.master) {
+            this.streamSend(this.master)
+          }
+          break
+        }
+        case SocketTypes.Allocate:
+          console.log('awaited', this.os8104.allocate())
+          break
+        case SocketTypes.GetSource: {
+          const message: GetSource = JSON.parse(data.toString())
+          // REVIEW don't particularly like this, had to add connection label as a chained property solely for this
+          //  call, need to look into alternatives, it feels like using an outer type (MostMessage in this case)
+          //  for a switch statement is not ideal
+          this.os8104.getRemoteSource(message.connectionLabel!)
+          break
+        }
+        case SocketTypes.Stream: {
+          const message: Stream = JSON.parse(data.toString())
+          this.os8104.stream(message)
+          break
+        }
+        case SocketTypes.RetrieveAudio: {
+          // TODO remove numbers from key in message
+          const message: RetrieveAudio = JSON.parse(data.toString())
+          this.os8104.retrieveAudio(message)
+        }
+      }
+    })
 
-        this.os8104.on(Os8104Events.MostMessageRx, (message: RawMostRxMessage) => {
-            // console.log('message', message)
-            if (!this.master) {
-                if (message.fBlockID === 2) {
-                    console.log("master found")
-                    this.master = {
-                        eventType: Os8104Events.MasterFoundEvent,
-                        instanceID: message.instanceID,
-                        sourceAddrHigh: message.sourceAddrHigh,
-                        sourceAddrLow: message.sourceAddrLow
-                    }
-                    this.streamSend(this.master)
-                }
-            }
-            const newMessage: SocketMostMessageRx = {
-                eventType: Os8104Events.SocketMostMessageRxEvent,
-                ...message
-            }
-            this.streamSend(newMessage)
-        })
-
-        this.os8104.on(Os8104Events.Shutdown, () => {
-            this.streamSend({eventType: 'shutDown'})
-        })
-
-        this.os8104.on(Os8104Events.AllocResult, (data: AllocResult) => {
-            this.streamSend({eventType: 'allocResult', ...data})
-        })
-
-        this.os8104.on(Os8104Events.MessageSent, () => {
-            this.streamSend({eventType: 'messageSent'})
-        })
-
-        this.os8104.on(Os8104Events.Locked, () => {
-            this.streamSend({eventType: 'locked'})
-        })
-
-        this.os8104.on(Os8104Events.Unlocked, () => {
-            this.streamSend({eventType: 'unlocked'})
-        })
-
-        process.on('SIGINT', () => {
-            console.log("Caught interrupt signal");
-            this.udpSocket.close()
-            process.exit();
-        });
-
+    try {
+      fs.unlinkSync('/tmp/SocketMost.sock')
+    } catch (e) {
+      /* swallow */
     }
+    this.udpSocket.bind('/tmp/SocketMost.sock')
+    this.connectInterval = setInterval(
+      () => this.udpSocket.connect('/tmp/SocketMost-client.sock'),
+      100,
+    )
+    this.os8104 = new OS8104A(
+      this.config.nodeAddress,
+      this.config.groupAddress,
+      this.config.freq,
+    )
 
-    streamSend = (data: MasterFoundEvent | SocketMostMessageRx | MessageOnly | AllocResult | NodePosition) => {
-        this.udpSocket.send(Buffer.from(JSON.stringify(data)))
-    }
+    this.os8104.on(Os8104Events.MostMessageRx, (message: MostRxMessage) => {
+      // console.log('message', message)
+      if (!this.master) {
+        if (message.fBlockID === 2) {
+          console.log('master found')
+          this.master = {
+            eventType: Os8104Events.MasterFoundEvent,
+            instanceID: message.instanceID,
+            sourceAddrHigh: message.sourceAddrHigh,
+            sourceAddrLow: message.sourceAddrLow,
+          }
+          this.streamSend(this.master)
+        }
+      }
+      const newMessage: MostRxMessage = {
+        eventType: Os8104Events.SocketMostMessageRxEvent,
+        ...message,
+      }
+      this.streamSend(newMessage)
+    })
+
+    this.os8104.on(Os8104Events.Shutdown, () => {
+      this.streamSend({ eventType: Os8104Events.Shutdown })
+    })
+
+    this.os8104.on(Os8104Events.AllocResult, (data: AllocResult) => {
+      this.streamSend({ eventType: Os8104Events.AllocResult, ...data })
+    })
+
+    this.os8104.on(Os8104Events.MessageSent, () => {
+      this.streamSend({ eventType: Os8104Events.MessageSent })
+    })
+
+    this.os8104.on(Os8104Events.Locked, () => {
+      this.streamSend({ eventType: Os8104Events.Locked })
+    })
+
+    this.os8104.on(Os8104Events.Unlocked, () => {
+      this.streamSend({ eventType: Os8104Events.Unlocked })
+    })
+
+    process.on('SIGINT', () => {
+      console.log('Caught interrupt signal')
+      this.udpSocket.close()
+      process.exit()
+    })
+  }
+
+  streamSend = (
+    data:
+      | MasterFoundEvent
+      | MostRxMessage
+      | MessageOnly
+      | AllocResult
+      | NodePosition,
+  ) => {
+    this.udpSocket.send(Buffer.from(JSON.stringify(data)))
+  }
 }


### PR DESCRIPTION
Tried to consolidate message types a bit more and re-use as much as possible across types - using generics to set the data type.

@rhysmorgan134 let me know what you think of this change :) 

I also moved the pi 5 config detection code to a separate method - looks like this was the intent with the enums.

Also it seems that the eslint/prettier config are not applied and my vscode setup automatically applies them when saving files, which changed indentation and formatting across files i touched
