### PR TITLE
Export messages from index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { SocketMost } from './server/SocketMost'
 import { SocketMostClient } from './client/SocketMost-Client'
 import { OS8104A } from './driver/OS8104A'
-
-export { SocketMost, SocketMostClient, OS8104A }
+import * as messages from './modules/Messages'
+export { SocketMost, SocketMostClient, OS8104A, messages }


### PR DESCRIPTION
Saw that JLR HU imports messages like so - 

`import {
  Os8104Events,
  RawMostRxMessage,
  SocketMostSendMessage,
  Stream
} from 'socketmost/dist/src/modules/Messages'`

Exporting these so that we can import without nested folders on the package path